### PR TITLE
fullPage: true?

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,7 +138,7 @@ var fs = require("fs");
 					});
 					await page.setViewport({width: 1440, height: 900});
 					await page.goto(url);
-					var screenshot = await page.screenshot({type: 'png'});
+					var screenshot = await page.screenshot({ type: 'png', fullPage: true });
 					resolve(await message.channel.send({files:[{ attachment: screenshot, name: "screenshot.png" }]}));
 				} catch(error) {
 					console.error(error);


### PR DESCRIPTION
Unsure if you were aware but passing fullPage: true into the page.screenshot command will return the whole page. Really useful for some websites like Wikipedia where you may want more info. Perhaps you could add it as an optional arg to the command?